### PR TITLE
[libc-trusty][x86] add 8 bytes alignment for the crtend.S

### DIFF
--- a/lib/libc-trusty/arch/x86/crtend.S
+++ b/lib/libc-trusty/arch/x86/crtend.S
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
+# define ASM_PTR_SIZE(x) .quad x
+# define ASM_ALIGN_TO_PTR_SIZE .balign 8
+
+
     .section .preinit_array, "aw"
-    .long 0
+    ASM_ALIGN_TO_PTR_SIZE
+    ASM_PTR_SIZE(0)
 
     .section .init_array, "aw"
-    .long 0
+    ASM_ALIGN_TO_PTR_SIZE
+    ASM_PTR_SIZE(0)
 
     .section .fini_array, "aw"
-    .long 0
-
+    ASM_ALIGN_TO_PTR_SIZE
+    ASM_PTR_SIZE(0)


### PR DESCRIPTION
Change-Id: I07461aea6c522dbd46c50a25011dbcdb8996ee80
Signed-off-by: Yan, Shaopu <shaopu.yan@intel.com>