### PR TITLE
make openssl stub return a valid tm result

### DIFF
--- a/lib/openssl-stubs/include/time.h
+++ b/lib/openssl-stubs/include/time.h
@@ -59,6 +59,8 @@ static inline struct tm *localtime(const time_t *t)
 
 static inline struct tm *OPENSSL_gmtime(const time_t *timer, struct tm* result) {
 	memset(result, 0, sizeof(*result));
+	/* the tm_mday valid range is [1,31], cannot return a zero */
+	result->tm_mday = 1;
 	return result;
 }
 


### PR DESCRIPTION
tm_mday valid range is [1,31], cannot return a zero

Change-Id: Ia14ceeb3561d4edd34b4b1fd711856ecb2f28e5f
Signed-off-by: Yan, Shaopu <shaopu.yan@intel.com>